### PR TITLE
Handle local package database errors better

### DIFF
--- a/src/metrics/databaseMetrics.ts
+++ b/src/metrics/databaseMetrics.ts
@@ -35,9 +35,14 @@ async function* iterateLocalDatabase(
   // do the async fetching loop
   const packageList = await getPkgList();
   for (const packageName of packageList) {
-    const packageMeta = await getPkgMetadata(packageName);
-    if (packageMeta) {
-      yield packageMeta;
+    try {
+      const packageMeta = await getPkgMetadata(packageName);
+      if (packageMeta) {
+        yield packageMeta;
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`WARN: Failed to fetch local package "${packageName}" for database metrics`);
     }
   }
 


### PR DESCRIPTION
If a 'local' package doesn't exist, we can just not count it.

Fixes #7 